### PR TITLE
Update requirements.txt for pykdtree version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,4 @@ pybullet==2.7.9
 trimesh
 cython
 numpy==1.9.5
-pykdtree==1.3.2
+pykdtree==1.3.0


### PR DESCRIPTION
Sorry for wrong expression about the version of pykdtree!
Limits a pykdtree version 1.3.0 that matches numpy version 1.9.5.