### PR TITLE
Limit the versions of pip and pykdtree

### DIFF
--- a/conda_env_gpu.yaml
+++ b/conda_env_gpu.yaml
@@ -7,7 +7,7 @@ channels:
 
 dependencies:
   - python=3.8
-  - pip
+  - pip<24.1
   - cudatoolkit=11.3
   - pytorch=1.10.2=py3.8_cuda11.3_cudnn8.2.0_0
   - torchvision

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,4 @@ pybullet==2.7.9
 trimesh
 cython
 numpy==1.9.5
-pykdtree==1.3.2
+pykdtree==1.3.0


### PR DESCRIPTION
Sorry for wrong expression of pykdtree version!
I tested this version of pip and pykdtree and they work fine.
Limits pip version lower than 24.1 that matches pytorch-lightning version 1.5.4.
Limits pykdtree version 1.3.0 that matches numpy version 1.9.5.
BTW, thanks for sharing the code!